### PR TITLE
🧪 TESTS: add ipykernel to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "cli": ["click", "click-completion", "click-log", "tabulate", "pyyaml"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],
         "testing": [
+            "ipykernel",
             "coverage",
             "pytest>=3.6,<4",
             "pytest-cov",


### PR DESCRIPTION
ipykernel must have been dropped from one of the other dependencies,
since it is no longer installed in the test environment.