### PR TITLE
UPDATE: SQLAlchemy 2.0

### DIFF
--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -7,8 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from sqlalchemy import JSON, Column, DateTime, Integer, String, Text
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.exc import IntegrityError, OperationalError
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, validates
+from sqlalchemy.orm import declarative_base, sessionmaker, validates
 from sqlalchemy.sql.expression import desc
 
 from jupyter_cache import __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "nbclient>=0.2,<0.6",
     "nbformat",
     "pyyaml",
-    "sqlalchemy>=1.3.12",
+    "sqlalchemy>=1.3.12,<2.1",
     "tabulate",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "nbclient>=0.2,<0.6",
     "nbformat",
     "pyyaml",
-    "sqlalchemy>=1.3.12,<1.5",
+    "sqlalchemy>=1.3.12",
     "tabulate",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "nbclient>=0.2,<0.6",
     "nbformat",
     "pyyaml",
-    "sqlalchemy>=1.3.12,<2.1",
+    "sqlalchemy>=1.3.12,<3",
     "tabulate",
 ]
 


### PR DESCRIPTION
As mentioned in #92, SQLAlchemy is pinned to <1.5. All tests pass with SQLAlchemy 2.0.6 - the only SQLAlchemy warning is:
```python
jupyter_cache/cache/db.py:17
  /home/jon/projects/jupyter-cache/jupyter_cache/cache/db.py:17: MovedIn20Warning: The ``declarative_base()`` 
function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 1.4) (Background on 
SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    OrmBase = declarative_base()
```
because of https://docs.sqlalchemy.org/en/20/changelog/migration_14.html#change-5508. [`sqlalchemy.ext.declarative.declarative_base` is still present.](https://github.com/sqlalchemy/sqlalchemy/blob/d9539e3990acf19ee1a03690d4a7441d26a7fbfd/lib/sqlalchemy/ext/declarative/__init__.py#L26-L27)