### PR TITLE
UPDATE: Drop Python 3.7, add Python 3.11, unpin myst-nb in docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - uses: pre-commit/action@v2.0.0
 
   tests:
@@ -27,10 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.9"
 
     runs-on: ${{ matrix.os }}
 
@@ -68,10 +68,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: install flit
       run: |
         pip install flit~=3.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       # for some reason the tests/conftest.py::check_nbs fixture breaks pytest-cov's cov-report outputting
       # this is why we run `coverage xml` afterwards (required by codecov)
     - name: Upload to Codecov
-      if: github.repository == 'executablebooks/jupyter-cache' && matrix.python-version == '3.9'
+      if: github.repository == 'executablebooks/jupyter-cache' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         name: jupyter-cache-pytests-py3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,15 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = ["sphinx extension material design web components"]
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 dependencies = [
     "attrs",
     "click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "attrs",
     "click",
     "importlib-metadata",
-    "nbclient>=0.2,<0.6",
+    "nbclient>=0.2,<0.8",
     "nbformat",
     "pyyaml",
     "sqlalchemy>=1.3.12,<3",
@@ -56,7 +56,7 @@ rtd = [
     "nbdime",
     "ipykernel",
     "jupytext",
-    "myst-nb @ git+https://github.com/executablebooks/MyST-NB.git",
+    "myst-nb",
     "sphinx-book-theme",
     "sphinx-copybutton",
 ]


### PR DESCRIPTION
A few version updates:

- Drop python 3.7 and add 3.11 (3.7 [is losing security support in a two months](https://devguide.python.org/versions/#versions))
- Unpin myst-nb which was making packaging hard