### PR TITLE
FIX: compatibility with SQLAlchemy < 1.4.0

### DIFF
--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -7,7 +7,11 @@ from typing import Any, Dict, List, Optional, Union
 from sqlalchemy import JSON, Column, DateTime, Integer, String, Text
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.exc import IntegrityError, OperationalError
-from sqlalchemy.orm import declarative_base, sessionmaker, validates
+try:
+    from sqlalchemy.orm import declarative_base  # sqlalchemy >= 1.4.0
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base  # sqlalchemy < 1.4.0
+from sqlalchemy.orm import sessionmaker, validates
 from sqlalchemy.sql.expression import desc
 
 from jupyter_cache import __version__

--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -7,10 +7,12 @@ from typing import Any, Dict, List, Optional, Union
 from sqlalchemy import JSON, Column, DateTime, Integer, String, Text
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.exc import IntegrityError, OperationalError
+
 try:
     from sqlalchemy.orm import declarative_base  # sqlalchemy >= 1.4.0
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base  # sqlalchemy < 1.4.0
+
 from sqlalchemy.orm import sessionmaker, validates
 from sqlalchemy.sql.expression import desc
 


### PR DESCRIPTION
Fixes https://github.com/executablebooks/jupyter-cache/pull/93#issuecomment-1518582253.

The alternative would be to require `sqlalchemy>=1.4.0`:
https://github.com/executablebooks/jupyter-cache/blob/87e0d740c7f7e12faba0993d411443e2e6b1f967/pyproject.toml#L34