### PR TITLE
DEV: Update API calls to ``datetime`` functionality

### DIFF
--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -52,7 +52,7 @@ def get_version(path: Union[str, Path]) -> Optional[str]:
 
 
 def datetime_utcnow():
-    return lambda : datetime.datetime.now(datetime.timezone.utc)
+    return lambda: datetime.datetime.now(datetime.timezone.utc)
 
 
 @contextmanager

--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from datetime import datetime
+import datetime
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -128,7 +128,7 @@ class NbProjectRecord(OrmBase):
     """A list of file assets required for the notebook to run."""
     exec_data = Column(JSON(), nullable=True)
     """Data on how to execute the notebook."""
-    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+    created = Column(DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC) )
     traceback = Column(Text(), nullable=True, default="")
     """A traceback is added if a notebook fails to execute fully."""
 
@@ -288,9 +288,9 @@ class NbCacheRecord(OrmBase):
     description = Column(String(255), nullable=False, default="")
     data = Column(JSON())
     """Extra data, such as the execution time."""
-    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+    created = Column(DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC))
     accessed = Column(
-        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.UTC), onupdate=lambda: datetime.datetime.now(datetime.UTC)
     )
 
     def __repr__(self):
@@ -368,7 +368,7 @@ class NbCacheRecord(OrmBase):
             record = session.query(NbCacheRecord).filter_by(pk=pk).one_or_none()
             if record is None:
                 raise KeyError(f"Cache record not found for NB with PK: {pk}")
-            record.accessed = datetime.utcnow()
+            record.accessed = datetime.datetime.now(datetime.UTC)
             session.commit()
 
     def touch_hashkey(hashkey, db: Engine):
@@ -379,7 +379,7 @@ class NbCacheRecord(OrmBase):
             )
             if record is None:
                 raise KeyError(f"Cache record not found for NB with hashkey: {hashkey}")
-            record.accessed = datetime.utcnow()
+            record.accessed = datetime.datetime.now(datetime.UTC)
             session.commit()
 
     @staticmethod

--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -53,9 +53,7 @@ def get_version(path: Union[str, Path]) -> Optional[str]:
 
 
 def datetime_utcnow():
-    if sys.version_info.minor >= 11:
-        return lambda : datetime.datetime.now(datetime.UTC)
-    return datetime.datetime.utcnow
+    return lambda : datetime.datetime.now(datetime.timezone.utc)
 
 
 @contextmanager

--- a/jupyter_cache/cache/db.py
+++ b/jupyter_cache/cache/db.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 import datetime
 import os
 from pathlib import Path
-import sys
 from typing import Any, Dict, List, Optional, Union
 
 from sqlalchemy import JSON, Column, DateTime, Integer, String, Text


### PR DESCRIPTION
Continues - https://github.com/executablebooks/jupyter-cache/pull/114. #114 uses the latest APIs from `datetime` which works with Python >= 3.11. However, one needs to make it work with Python 3.9, Python 3.10 as well. For that one has to use `datetime.timezone.utc` and not `datetime.UTC` (available only in >= 3.11). See the review thread - https://github.com/executablebooks/jupyter-cache/pull/117#discussion_r1727041859

The API calls in `main` are depreciated. I have updated these calls to comply with the latest versions. If I use ``main`` to build SciPy docs with `myst_nb` execution mode set to ``cache`` then I get the following errors,

```zsh
reading sources... [  3%] reference/generated/scipy.cluster.hierarchy.DisjointSet.add .. reference/generated/scipy.fft.ifft
(Error in parallel process)
Traceback (most recent call last):
  File "/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.12/site-packages/sphinx/util/parallel.py", line 76, in _process
    ret = func(arg)
          ^^^^^^^^^
  File "/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 495, in read_process
    self.read_doc(docname, _cache=False)
  File "/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 536, in read_doc
    publisher.publish()
  File "/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.12/site-packages/docutils/core.py", line 234, in publish
    self.document = self.reader.read(self.source, self.parser,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.12/site-packages/sphinx/io.py", line 106, in read
    self.parse()
  File "/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.12/site-packages/docutils/readers/__init__.py", line 76, in parse
    self.parser.parse(self.input, document)
  File "/Users/czgdp1807/Quansight/MyST-NB/myst_nb/sphinx_.py", line 152, in parse
    with create_client(
  File "/Users/czgdp1807/Quansight/MyST-NB/myst_nb/core/execute/base.py", line 79, in __enter__
    self.start_client()
  File "/Users/czgdp1807/Quansight/MyST-NB/myst_nb/core/execute/cache.py", line 36, in start_client
    _, self._notebook = cache.merge_match_into_notebook(self.notebook)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/czgdp1807/Quansight/jupyter-cache/jupyter_cache/cache/main.py", line 357, in merge_match_into_notebook
    cache_nb = self.get_cache_bundle(pk).nb
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/czgdp1807/Quansight/jupyter-cache/jupyter_cache/cache/main.py", line 296, in get_cache_bundle
    NbCacheRecord.touch(pk, self.db)
  File "/Users/czgdp1807/Quansight/jupyter-cache/jupyter_cache/cache/db.py", line 371, in touch
    record.accessed = datetime.utcnow()
                      ^^^^^^^^^^^^^^^^^
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

Sphinx parallel build error:
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
make: *** [html-build] Error 2
``` 

With my PR I get the following,

```zsh
writing additional pages... search done
copying images... [  9%] ../build/plot_directive/reference/generated/scipy-interpolate-SmoothSphereBivariateSpline-__call__-1.pn
copying images... [100%] ../build/plot_directive/tutorial/stats/sampling_srou-1.png
dumping search index in English (code: en)... done
dumping object inventory... done
[jupyterlite-sphinx] Running JupyterLite build
[jupyterlite-sphinx] JupyterLite build done
build succeeded.

The HTML pages are in build/html.
```