### PR TITLE
CI: add cron and workflow dispatch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: continuous-integration
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,8 @@ on:
     tags:
       - 'v*'
   pull_request:
-
+  schedule:
+    - cron:  '0 5 * * 1'
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,15 @@ name: continuous-integration
 
 on:
   push:
-    branches: [main]
+    branches:
+    - main
     tags:
-      - 'v*'
+    - '*'
   pull_request:
   schedule:
     - cron:  '0 5 * * 1'
+  workflow_dispatch:
+
 
 jobs:
   pre-commit:


### PR DESCRIPTION
For a low-traffic repo it's especially useful to run CI in cron, so any new incompatibility has a chance to be noticed before users start reporting it.

I also added workflow_dispatch for manual CI trigger, and some minor cleanup.

