### PR TITLE
CONF: adding sphinx config file explicitely to RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,6 @@ python:
           - rtd
 
 sphinx:
+  configuration: docs/conf.py
   builder: html
   fail_on_warning: true


### PR DESCRIPTION
This should fix the RTD failure we see in https://github.com/executablebooks/jupyter-cache/pull/136